### PR TITLE
Add try except to velCheckMain

### DIFF
--- a/hecrasio/qaqc.py
+++ b/hecrasio/qaqc.py
@@ -427,9 +427,13 @@ def group_excessive_points(gdf: gpd.geodataframe.GeoDataFrame, cell_size: float)
     gdf_aois['point'] = gdf.geometry
     gdf_aois['polygon'] = gdf_aois.point.apply(lambda row: row.buffer(cell_size * 3))
     gdf_aois['geometry'] = gdf_aois['polygon']
-
-    diss_aois = list(cascaded_union(gdf_aois.geometry))
-    gdf_diss_aois = gpd.GeoDataFrame(diss_aois, columns=['geometry'])
+    
+    try:
+        diss_aois = list(cascaded_union(gdf_aois.geometry))
+        gdf_diss_aois = gpd.GeoDataFrame(diss_aois, columns=['geometry'])
+    except:
+        diss_aois = cascaded_union(gdf_aois.geometry)
+        gdf_diss_aois = gpd.GeoDataFrame([diss_aois], columns=['geometry'])
     return gdf_diss_aois
 
 

--- a/notebooks/QAQC-PluvialTest.ipynb
+++ b/notebooks/QAQC-PluvialTest.ipynb
@@ -925,6 +925,18 @@
    "language": "python",
    "name": "python3"
   },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
   "nteract": {
    "version": "0.14.4"
   },


### PR DESCRIPTION
This PR resolves Issue #4 where `velCheckMain` was reported as failing.

`velCheckMain` calls `group_excessive_points`. The bug is resolved by placing:
```python
diss_aois = list(cascaded_union(gdf_aois.geometry))
```
In a try except clause.